### PR TITLE
添加支持自定义级联脱敏注解,方便使用者进行二次封装

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,11 +470,12 @@ private String testField;
 
 # 自定义注解
 
-v0.0.4 新增功能。允许功能自定义条件注解和策略注解。
+- v0.0.4 新增功能。允许功能自定义条件注解和策略注解。
+- v0.0.11 新增功能。允许功能自定义级联脱敏注解。
 
-## 案例
+## 案例1
 
-### 自定义注解
+### 自定义密码脱敏策略&自定义密码脱敏策略生效条件
 
 - 策略脱敏
 
@@ -616,6 +617,114 @@ private CustomPasswordModel buildCustomPasswordModel(){
     model.setPassword("hello");
     model.setFooPassword("123456");
     return model;
+}
+```
+
+- v0.0.11 新增功能。允许功能自定义级联脱敏注解。
+
+## 案例2
+
+### 自定义级联脱敏注解
+
+
+- 自定义级联脱敏注解
+
+```java
+/**
+ * 级联脱敏注解,如果对象中属性为另外一个对象(集合)，则可以使用这个注解指定。
+ * <p>
+ * 1. 如果属性为 Iterable 的子类集合，则当做列表处理，遍历其中的对象
+ * 2. 如果是普通对象，则处理对象中的脱敏信息
+ * 3. 如果是普通字段/MAP，则不做处理
+ *
+ * @author dev-sxl
+ * date 2020-09-14
+ * @since 0.0.11
+ */
+@Inherited
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@SensitiveEntry
+public @interface SensitiveEntryCustom {
+}
+```
+
+### 定义测试对象
+
+定义一个使用自定义注解的对象。
+ 
+```java
+public class CustomUserEntryObject {
+
+    @SensitiveEntryCustom
+    private User user;
+
+    @SensitiveEntryCustom
+    private List<User> userList;
+
+    @SensitiveEntryCustom
+    private User[] userArray;
+
+    // 其他方法...
+}
+```
+
+### 测试
+
+```java
+/**
+ * 用户属性中有集合或者对象，集合中属性是对象-脱敏测试
+ * @since 0.0.10
+ */
+@Test
+public void customSensitiveEntryObjectTest() {
+    final String originalStr = "CustomUserEntryObject{user=User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}, userList=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}], userArray=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}]}";
+    final String sensitiveStr = "CustomUserEntryObject{user=User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}, userList=[User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}], userArray=[User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}]}";
+
+    CustomUserEntryObject userEntryObject = DataPrepareTest.buildCustomUserEntryObject();
+    Assert.assertEquals(originalStr, userEntryObject.toString());
+
+    CustomUserEntryObject sensitiveUserEntryObject = SensitiveUtil.desCopy(userEntryObject);
+    Assert.assertEquals(sensitiveStr, sensitiveUserEntryObject.toString());
+    Assert.assertEquals(originalStr, userEntryObject.toString());
+}
+```
+
+构建对象的方法如下：
+
+```java
+/**
+ * 构建用户-属性为列表，数组。列表中为对象。
+ *
+ * @return 构建嵌套信息
+ * @since 0.0.11
+ */
+public static CustomUserEntryObject buildCustomUserEntryObject() {
+    CustomUserEntryObject userEntryObject = new CustomUserEntryObject();
+    User user = buildUser();
+    User user2 = buildUser();
+    User user3 = buildUser();
+    userEntryObject.setUser(user);
+    userEntryObject.setUserList(Arrays.asList(user2));
+    userEntryObject.setUserArray(new User[]{user3});
+    return userEntryObject;
+}
+
+/**
+ * 构建测试用户对象
+ *
+ * @return 创建后的对象
+ * @since 0.0.1
+ */
+public static User buildUser() {
+    User user = new User();
+    user.setUsername("脱敏君");
+    user.setPassword("1234567");
+    user.setEmail("12345@qq.com");
+    user.setIdCard("123456190001011234");
+    user.setPhone("18888888888");
+    return user;
 }
 ```
 

--- a/sensitive-annotation/src/main/java/com/github/houbb/sensitive/annotation/SensitiveEntry.java
+++ b/sensitive-annotation/src/main/java/com/github/houbb/sensitive/annotation/SensitiveEntry.java
@@ -4,17 +4,18 @@ import java.lang.annotation.*;
 
 /**
  * 如果对象中属性为另外一个对象(集合)，则可以使用这个注解指定。
- *
+ * <p>
  * 1. 如果属性为 Iterable 的子类集合，则当做列表处理，遍历其中的对象
  * 2. 如果是普通对象，则处理对象中的脱敏信息
  * 3. 如果是普通字段/MAP，则不做处理
+ *
  * @author binbin.hou
  * date 2019/01/09
  * @since 0.0.2
  */
 @Inherited
 @Documented
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SensitiveEntry {
 }

--- a/sensitive-core/src/main/java/com/github/houbb/sensitive/core/api/SensitiveService.java
+++ b/sensitive-core/src/main/java/com/github/houbb/sensitive/core/api/SensitiveService.java
@@ -10,7 +10,6 @@ import com.github.houbb.heaven.util.lang.reflect.ClassUtil;
 import com.github.houbb.heaven.util.util.ArrayUtil;
 import com.github.houbb.heaven.util.util.CollectionUtil;
 import com.github.houbb.sensitive.annotation.Sensitive;
-import com.github.houbb.sensitive.annotation.SensitiveEntry;
 import com.github.houbb.sensitive.annotation.metadata.SensitiveCondition;
 import com.github.houbb.sensitive.annotation.metadata.SensitiveStrategy;
 import com.github.houbb.sensitive.api.*;
@@ -18,7 +17,6 @@ import com.github.houbb.sensitive.api.impl.SensitiveStrategyBuiltIn;
 import com.github.houbb.sensitive.core.api.context.SensitiveContext;
 import com.github.houbb.sensitive.core.exception.SensitiveRuntimeException;
 import com.github.houbb.sensitive.core.support.filter.DefaultContextValueFilter;
-import com.github.houbb.sensitive.core.util.*;
 import com.github.houbb.sensitive.core.util.strategy.SensitiveStrategyBuiltInUtil;
 
 import java.lang.annotation.Annotation;
@@ -58,7 +56,7 @@ public class SensitiveService<T> implements ISensitive<T> {
 
     @Override
     public String desJson(final T object, final ISensitiveConfig config) {
-        if(ObjectUtil.isNull(object)) {
+        if (ObjectUtil.isNull(object)) {
             return JSON.toJSONString(object);
         }
 
@@ -90,8 +88,8 @@ public class SensitiveService<T> implements ISensitive<T> {
                 context.setCurrentField(field);
 
                 // 处理 @SensitiveEntry 注解
-                SensitiveEntry sensitiveEntry = field.getAnnotation(SensitiveEntry.class);
-                if (ObjectUtil.isNotNull(sensitiveEntry)) {
+                boolean isSensitiveEntry = context.haveSensitiveEntryAnnotation(field);
+                if (isSensitiveEntry) {
                     if (ClassTypeUtil.isJavaBean(fieldTypeClass)) {
                         // 为普通 javabean 对象
                         final Object fieldNewObject = field.get(copyObject);

--- a/sensitive-core/src/main/java/com/github/houbb/sensitive/core/api/context/SensitiveContext.java
+++ b/sensitive-core/src/main/java/com/github/houbb/sensitive/core/api/context/SensitiveContext.java
@@ -1,15 +1,18 @@
 package com.github.houbb.sensitive.core.api.context;
 
 import com.github.houbb.heaven.annotation.NotThreadSafe;
+import com.github.houbb.sensitive.annotation.SensitiveEntry;
 import com.github.houbb.sensitive.api.IContext;
 import com.github.houbb.sensitive.core.exception.SensitiveRuntimeException;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * 脱敏上下文
+ *
  * @author binbin.hou
  * date 2019/1/2
  * @since 0.0.1
@@ -34,18 +37,21 @@ public class SensitiveContext implements IContext {
 
     /**
      * 类信息
+     *
      * @since 0.0.6
      */
     private Class beanClass;
 
     /**
      * 明细信息
+     *
      * @since 0.0.6
      */
     private Object entry;
 
     /**
      * 新建一个对象实例
+     *
      * @return this
      * @since 0.0.6
      */
@@ -68,8 +74,8 @@ public class SensitiveContext implements IContext {
     }
 
     /**
-     * @since 0.0.4
      * @return 获取当前字段名称
+     * @since 0.0.4
      */
     @Override
     public String getCurrentFieldName() {
@@ -77,8 +83,8 @@ public class SensitiveContext implements IContext {
     }
 
     /**
-     * @since 0.0.4
      * @return 获取当前字段值
+     * @since 0.0.4
      */
     @Override
     public Object getCurrentFieldValue() {
@@ -100,6 +106,7 @@ public class SensitiveContext implements IContext {
 
     /**
      * 设置当前字段
+     *
      * @param allFieldList 所有字段列表
      */
     public void setAllFieldList(List<Field> allFieldList) {
@@ -109,6 +116,7 @@ public class SensitiveContext implements IContext {
     /**
      * 添加字段信息
      * 本方法不再使用，将在下个版本直接移除。
+     *
      * @param fieldList 字段列表信息
      */
     @Deprecated
@@ -132,6 +140,28 @@ public class SensitiveContext implements IContext {
 
     public void setEntry(Object entry) {
         this.entry = entry;
+    }
+
+    /**
+     * 字段上是否直接或间接包含@SensitiveEntry
+     *
+     * @param field 字段
+     * @since 0.0.11
+     */
+    public boolean haveSensitiveEntryAnnotation(Field field) {
+        // 属性上直接含有@SensitiveEntry注解
+        SensitiveEntry sensitiveEntry = field.getAnnotation(SensitiveEntry.class);
+        if (sensitiveEntry != null) {
+            return true;
+        }
+        // 属性上包含自定义的对象属性(间接@SensitiveEntry)注解
+        for (Annotation annotation : field.getAnnotations()) {
+            sensitiveEntry = annotation.annotationType().getAnnotation(SensitiveEntry.class);
+            if (sensitiveEntry != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/sensitive-core/src/main/java/com/github/houbb/sensitive/core/support/filter/DefaultContextValueFilter.java
+++ b/sensitive-core/src/main/java/com/github/houbb/sensitive/core/support/filter/DefaultContextValueFilter.java
@@ -68,8 +68,8 @@ public class DefaultContextValueFilter implements ContextValueFilter {
 
         // 这里将缺少对于列表/集合/数组 的处理。可以单独实现。
         // 设置当前处理的字段
-        SensitiveEntry sensitiveEntry = field.getAnnotation(SensitiveEntry.class);
-        if(ObjectUtil.isNull(sensitiveEntry)) {
+        boolean haveSensitiveEntry = sensitiveContext.haveSensitiveEntryAnnotation(field);
+        if(!haveSensitiveEntry) {
             sensitiveContext.setEntry(value);
             return handleSensitive(sensitiveContext, field);
         }

--- a/sensitive-test/src/test/java/com/github/houbb/sensitive/test/annotation/custom/SensitiveEntryCustom.java
+++ b/sensitive-test/src/test/java/com/github/houbb/sensitive/test/annotation/custom/SensitiveEntryCustom.java
@@ -1,0 +1,24 @@
+package com.github.houbb.sensitive.test.annotation.custom;
+
+import com.github.houbb.sensitive.annotation.SensitiveEntry;
+
+import java.lang.annotation.*;
+
+/**
+ * 如果对象中属性为另外一个对象(集合)，则可以使用这个注解指定。(自定义)
+ * <p>
+ * 1. 如果属性为 Iterable 的子类集合，则当做列表处理，遍历其中的对象
+ * 2. 如果是普通对象，则处理对象中的脱敏信息
+ * 3. 如果是普通字段/MAP，则不做处理
+ *
+ * @author dev-sxl
+ * date 2020-09-14
+ * @since 0.0.11
+ */
+@Inherited
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@SensitiveEntry
+public @interface SensitiveEntryCustom {
+}

--- a/sensitive-test/src/test/java/com/github/houbb/sensitive/test/core/DataPrepareTest.java
+++ b/sensitive-test/src/test/java/com/github/houbb/sensitive/test/core/DataPrepareTest.java
@@ -2,10 +2,7 @@ package com.github.houbb.sensitive.test.core;
 
 
 import com.github.houbb.sensitive.test.model.sensitive.User;
-import com.github.houbb.sensitive.test.model.sensitive.entry.UserCollection;
-import com.github.houbb.sensitive.test.model.sensitive.entry.UserEntryBaseType;
-import com.github.houbb.sensitive.test.model.sensitive.entry.UserEntryObject;
-import com.github.houbb.sensitive.test.model.sensitive.entry.UserGroup;
+import com.github.houbb.sensitive.test.model.sensitive.entry.*;
 import com.github.houbb.sensitive.test.model.sensitive.system.SystemBuiltInAt;
 import com.github.houbb.sensitive.test.model.sensitive.system.SystemBuiltInAtEntry;
 import com.github.houbb.sensitive.test.model.sensitive.system.SystemBuiltInMixed;
@@ -14,6 +11,7 @@ import java.util.*;
 
 /**
  * 数据准备工具
+ *
  * @author binbin.hou
  * date 2019/1/9
  */
@@ -21,11 +19,25 @@ public final class DataPrepareTest {
 
     /**
      * 构建用户-属性为列表，列表中为基础属性
+     *
      * @return 构建嵌套信息
      * @since 0.0.2
      */
     public static UserEntryBaseType buildUserEntryBaseType() {
         UserEntryBaseType userEntryBaseType = new UserEntryBaseType();
+        userEntryBaseType.setChineseNameList(Arrays.asList("盘古", "女娲", "伏羲"));
+        userEntryBaseType.setChineseNameArray(new String[]{"盘古", "女娲", "伏羲"});
+        return userEntryBaseType;
+    }
+
+    /**
+     * 构建用户-属性为列表，列表中为基础属性
+     *
+     * @return 构建嵌套信息
+     * @since 0.0.11
+     */
+    public static CustomUserEntryBaseType buildCustomUserEntryBaseType() {
+        CustomUserEntryBaseType userEntryBaseType = new CustomUserEntryBaseType();
         userEntryBaseType.setChineseNameList(Arrays.asList("盘古", "女娲", "伏羲"));
         userEntryBaseType.setChineseNameArray(new String[]{"盘古", "女娲", "伏羲"});
         return userEntryBaseType;
@@ -48,7 +60,25 @@ public final class DataPrepareTest {
     }
 
     /**
+     * 构建用户-属性为列表，数组。列表中为对象。
+     *
+     * @return 构建嵌套信息
+     * @since 0.0.11
+     */
+    public static CustomUserEntryObject buildCustomUserEntryObject() {
+        CustomUserEntryObject userEntryObject = new CustomUserEntryObject();
+        User user = buildUser();
+        User user2 = buildUser();
+        User user3 = buildUser();
+        userEntryObject.setUser(user);
+        userEntryObject.setUserList(Arrays.asList(user2));
+        userEntryObject.setUserArray(new User[]{user3});
+        return userEntryObject;
+    }
+
+    /**
      * 构建用户-属性为列表，数组，对象
+     *
      * @return 对象
      * @since 0.0.2
      */
@@ -70,7 +100,31 @@ public final class DataPrepareTest {
     }
 
     /**
+     * 构建用户-属性为列表，数组，对象
+     *
+     * @return 对象
+     * @since 0.0.11
+     */
+    public static CustomUserGroup buildCustomUserGroup() {
+        CustomUserGroup userGroup = new CustomUserGroup();
+        User user = buildUser();
+        User coolUser = buildUser();
+
+        userGroup.setPassword("123456");
+        userGroup.setCoolUser(coolUser);
+        userGroup.setUser(user);
+        userGroup.setUserCollection(Collections.singletonList(user));
+        userGroup.setUserList(Arrays.asList(user));
+        userGroup.setUserSet(new HashSet<>(Arrays.asList(user)));
+        Map<String, User> map = new HashMap<>();
+        map.put("map", user);
+        userGroup.setUserMap(map);
+        return userGroup;
+    }
+
+    /**
      * 构建测试用户对象
+     *
      * @return 创建后的对象
      * @since 0.0.1
      */
@@ -86,6 +140,7 @@ public final class DataPrepareTest {
 
     /**
      * 构建系统内置对象
+     *
      * @return 构建后的对象
      * @since 0.0.3
      */
@@ -101,6 +156,7 @@ public final class DataPrepareTest {
 
     /**
      * 构建系统内置对象
+     *
      * @return 构建后的对象
      * @since 0.0.3
      */
@@ -113,6 +169,7 @@ public final class DataPrepareTest {
 
     /**
      * 构建系统内置+Sensitive 注解混合测试
+     *
      * @return 混合
      * @since 0.0.3
      */
@@ -124,6 +181,7 @@ public final class DataPrepareTest {
 
     /**
      * 构建用户-属性为列表，数组，对象、数组
+     *
      * @return 对象
      * @since 0.0.6
      */
@@ -142,7 +200,28 @@ public final class DataPrepareTest {
     }
 
     /**
+     * 构建用户-属性为列表，数组，对象、数组
+     *
+     * @return 对象
+     * @since 0.0.11
+     */
+    public static CustomUserCollection buildCustomUserCollection() {
+        CustomUserCollection userCollection = new CustomUserCollection();
+        User user = buildUser();
+
+        userCollection.setUserCollection(Collections.singletonList(user));
+        userCollection.setUserList(Arrays.asList(user));
+        userCollection.setUserSet(new HashSet<>(Arrays.asList(user)));
+        userCollection.setUserArray(new User[]{user});
+        Map<String, User> map = new HashMap<>();
+        map.put("map", user);
+        userCollection.setUserMap(map);
+        return userCollection;
+    }
+
+    /**
      * 构建用户列表
+     *
      * @return 构建的列表
      * @since 0.0.7
      */

--- a/sensitive-test/src/test/java/com/github/houbb/sensitive/test/core/sensitive/entry/CustomSensitiveEntryTest.java
+++ b/sensitive-test/src/test/java/com/github/houbb/sensitive/test/core/sensitive/entry/CustomSensitiveEntryTest.java
@@ -1,0 +1,117 @@
+package com.github.houbb.sensitive.test.core.sensitive.entry;
+
+import com.alibaba.fastjson.JSON;
+import com.github.houbb.sensitive.core.api.SensitiveUtil;
+import com.github.houbb.sensitive.test.core.DataPrepareTest;
+import com.github.houbb.sensitive.test.model.sensitive.entry.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * SensitiveEntry 注解-脱敏测试类
+ * @author dev-sxl
+ * date 2020-09-14
+ * @since 0.0.10
+ */
+public class CustomSensitiveEntryTest {
+
+    /**
+     * 用户属性中有集合或者map，集合中属性是基础类型-脱敏测试
+     * @since 0.0.10
+     */
+    @Test
+    public void sensitiveEntryBaseTypeTest() {
+        final String originalStr = "CustomUserEntryBaseType{chineseNameList=[盘古, 女娲, 伏羲], chineseNameArray=[盘古, 女娲, 伏羲]}";
+        final String sensitiveStr = "CustomUserEntryBaseType{chineseNameList=[*古, *娲, *羲], chineseNameArray=[*古, *娲, *羲]}";
+
+        CustomUserEntryBaseType userEntryBaseType = DataPrepareTest.buildCustomUserEntryBaseType();
+        Assert.assertEquals(originalStr, userEntryBaseType.toString());
+
+        CustomUserEntryBaseType sensitive = SensitiveUtil.desCopy(userEntryBaseType);
+        Assert.assertEquals(sensitiveStr, sensitive.toString());
+        Assert.assertEquals(originalStr, userEntryBaseType.toString());
+    }
+
+    /**
+     * 用户属性中有集合或者对象，集合中属性是对象-脱敏测试
+     * @since 0.0.10
+     */
+    @Test
+    public void sensitiveEntryObjectTest() {
+        final String originalStr = "CustomUserEntryObject{user=User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}, userList=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}], userArray=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}]}";
+        final String sensitiveStr = "CustomUserEntryObject{user=User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}, userList=[User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}], userArray=[User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}]}";
+
+        CustomUserEntryObject userEntryObject = DataPrepareTest.buildCustomUserEntryObject();
+        Assert.assertEquals(originalStr, userEntryObject.toString());
+
+        CustomUserEntryObject sensitiveUserEntryObject = SensitiveUtil.desCopy(userEntryObject);
+        Assert.assertEquals(sensitiveStr, sensitiveUserEntryObject.toString());
+        Assert.assertEquals(originalStr, userEntryObject.toString());
+    }
+
+    /**
+     * 用户属性中有集合或者对象-脱敏测试
+     * @since 0.0.10
+     */
+    @Test
+    public void sensitiveUserGroupTest() {
+        final String originalStr = "CustomUserGroup{coolUser=User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}, user=User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}, userList=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}], userSet=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}], userCollection=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}], password='123456', userMap={map=User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}}}";
+        final String sensitiveStr = "CustomUserGroup{coolUser=User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}, user=User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}, userList=[User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}], userSet=[User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}], userCollection=[User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}], password='123456', userMap={map=User{username='脱*君', idCard='123456**********34', password='null', email='123**@qq.com', phone='188****8888'}}}";
+
+        CustomUserGroup userGroup = DataPrepareTest.buildCustomUserGroup();
+        Assert.assertEquals(originalStr, userGroup.toString());
+
+        CustomUserGroup sensitiveUserGroup = SensitiveUtil.desCopy(userGroup);
+        Assert.assertEquals(sensitiveStr, sensitiveUserGroup.toString());
+        Assert.assertEquals(originalStr, userGroup.toString());
+    }
+
+    /**
+     * 用户属性中有集合或者map，集合中属性是基础类型-脱敏测试-JSON
+     * @since 0.0.6
+     */
+    @Test
+    public void sensitiveEntryBaseTypeJsonTest() {
+        final String originalStr = "CustomUserEntryBaseType{chineseNameList=[盘古, 女娲, 伏羲], chineseNameArray=[盘古, 女娲, 伏羲]}";
+        final String sensitiveJson = "{\"chineseNameArray\":[\"*古\",\"*娲\",\"*羲\"],\"chineseNameList\":[\"*古\",\"*娲\",\"*羲\"]}";
+
+        CustomUserEntryBaseType userEntryBaseType = DataPrepareTest.buildCustomUserEntryBaseType();
+
+        Assert.assertEquals(sensitiveJson, SensitiveUtil.desJson(userEntryBaseType));
+        Assert.assertEquals(originalStr, userEntryBaseType.toString());
+    }
+
+    /**
+     * 用户属性中有集合或者对象，集合中属性是对象-脱敏测试-JSON
+     * @since 0.0.6
+     */
+    @Test
+    public void sensitiveEntryObjectJsonTest() {
+        final String originalStr = "CustomUserEntryObject{user=User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}, userList=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}], userArray=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}]}";
+        final String sensitiveJson = "{\"user\":{\"email\":\"123**@qq.com\",\"idCard\":\"123456**********34\",\"phone\":\"188****8888\",\"username\":\"脱*君\"},\"userArray\":[{\"email\":\"123**@qq.com\",\"idCard\":\"123456**********34\",\"phone\":\"188****8888\",\"username\":\"脱*君\"}],\"userList\":[{\"email\":\"123**@qq.com\",\"idCard\":\"123456**********34\",\"phone\":\"188****8888\",\"username\":\"脱*君\"}]}";
+
+        CustomUserEntryObject userEntryObject = DataPrepareTest.buildCustomUserEntryObject();
+
+        Assert.assertEquals(sensitiveJson, SensitiveUtil.desJson(userEntryObject));
+        Assert.assertEquals(originalStr, userEntryObject.toString());
+    }
+
+    /**
+     * 用户属性中有集合或者对象-脱敏测试-JSON
+     * 备注：当为对象前台集合对象时，FastJSON 本身的转换结果就是不尽人意的。（或者说是 JSON 的规范）
+     * @since 0.0.6
+     */
+    @Test
+    public void sensitiveUserCollectionJsonTest() {
+        final String originalStr = "CustomUserCollection{userList=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}], userSet=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}], userCollection=[User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}], userMap={map=User{username='脱敏君', idCard='123456190001011234', password='1234567', email='12345@qq.com', phone='18888888888'}}}";
+        final String commonJson = "{\"userArray\":[{\"email\":\"12345@qq.com\",\"idCard\":\"123456190001011234\",\"password\":\"1234567\",\"phone\":\"18888888888\",\"username\":\"脱敏君\"}],\"userCollection\":[{\"$ref\":\"$.userArray[0]\"}],\"userList\":[{\"$ref\":\"$.userArray[0]\"}],\"userMap\":{\"map\":{\"$ref\":\"$.userArray[0]\"}},\"userSet\":[{\"$ref\":\"$.userArray[0]\"}]}";
+        final String sensitiveJson = "{\"userArray\":[{\"email\":\"123**@qq.com\",\"idCard\":\"123456**********34\",\"phone\":\"188****8888\",\"username\":\"脱*君\"}],\"userCollection\":[{\"$ref\":\"$.userArray[0]\"}],\"userList\":[{\"$ref\":\"$.userArray[0]\"}],\"userMap\":{\"map\":{\"$ref\":\"$.userArray[0]\"}},\"userSet\":[{\"$ref\":\"$.userArray[0]\"}]}";
+
+        CustomUserCollection userCollection = DataPrepareTest.buildCustomUserCollection();
+
+        Assert.assertEquals(commonJson, JSON.toJSONString(userCollection));
+        Assert.assertEquals(sensitiveJson, SensitiveUtil.desJson(userCollection));
+        Assert.assertEquals(originalStr, userCollection.toString());
+    }
+
+}

--- a/sensitive-test/src/test/java/com/github/houbb/sensitive/test/model/sensitive/entry/CustomUserCollection.java
+++ b/sensitive-test/src/test/java/com/github/houbb/sensitive/test/model/sensitive/entry/CustomUserCollection.java
@@ -1,0 +1,87 @@
+package com.github.houbb.sensitive.test.model.sensitive.entry;
+
+import com.github.houbb.sensitive.test.annotation.custom.SensitiveEntryCustom;
+import com.github.houbb.sensitive.test.model.sensitive.User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 对象集合
+ * @author dev-sxl
+ * date 2020-09-14
+ * @since 0.0.11
+ */
+public class CustomUserCollection {
+
+    @SensitiveEntryCustom
+    private User[] userArray;
+
+    @SensitiveEntryCustom
+    private List<User> userList;
+
+    @SensitiveEntryCustom
+    private Set<User> userSet;
+
+    @SensitiveEntryCustom
+    private Collection<User> userCollection;
+
+    /**
+     * SensitiveEntry 注解不会生效
+     */
+    @SensitiveEntryCustom
+    private Map<String, User> userMap;
+
+    public User[] getUserArray() {
+        return userArray;
+    }
+
+    public void setUserArray(User[] userArray) {
+        this.userArray = userArray;
+    }
+
+    public List<User> getUserList() {
+        return userList;
+    }
+
+    public void setUserList(List<User> userList) {
+        this.userList = userList;
+    }
+
+    public Set<User> getUserSet() {
+        return userSet;
+    }
+
+    public void setUserSet(Set<User> userSet) {
+        this.userSet = userSet;
+    }
+
+    public Collection<User> getUserCollection() {
+        return userCollection;
+    }
+
+    public void setUserCollection(Collection<User> userCollection) {
+        this.userCollection = userCollection;
+    }
+
+    public Map<String, User> getUserMap() {
+        return userMap;
+    }
+
+    public void setUserMap(Map<String, User> userMap) {
+        this.userMap = userMap;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomUserCollection{" +
+                "userList=" + userList +
+                ", userSet=" + userSet +
+                ", userCollection=" + userCollection +
+                ", userMap=" + userMap +
+                '}';
+    }
+
+}

--- a/sensitive-test/src/test/java/com/github/houbb/sensitive/test/model/sensitive/entry/CustomUserEntryBaseType.java
+++ b/sensitive-test/src/test/java/com/github/houbb/sensitive/test/model/sensitive/entry/CustomUserEntryBaseType.java
@@ -1,0 +1,51 @@
+package com.github.houbb.sensitive.test.model.sensitive.entry;
+
+import com.github.houbb.sensitive.annotation.Sensitive;
+import com.github.houbb.sensitive.core.api.strategory.StrategyChineseName;
+import com.github.houbb.sensitive.test.annotation.custom.SensitiveEntryCustom;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 属性为列表，列表中放置的为基础属性
+ *
+ * @author dev-sxl
+ * date 2020-09-14
+ * @since 0.0.11
+ */
+public class CustomUserEntryBaseType {
+
+
+    @SensitiveEntryCustom
+    @Sensitive(strategy = StrategyChineseName.class)
+    private List<String> chineseNameList;
+
+    @SensitiveEntryCustom
+    @Sensitive(strategy = StrategyChineseName.class)
+    private String[] chineseNameArray;
+
+    public List<String> getChineseNameList() {
+        return chineseNameList;
+    }
+
+    public void setChineseNameList(List<String> chineseNameList) {
+        this.chineseNameList = chineseNameList;
+    }
+
+    public String[] getChineseNameArray() {
+        return chineseNameArray;
+    }
+
+    public void setChineseNameArray(String[] chineseNameArray) {
+        this.chineseNameArray = chineseNameArray;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomUserEntryBaseType{" +
+                "chineseNameList=" + chineseNameList +
+                ", chineseNameArray=" + Arrays.toString(chineseNameArray) +
+                '}';
+    }
+}

--- a/sensitive-test/src/test/java/com/github/houbb/sensitive/test/model/sensitive/entry/CustomUserEntryObject.java
+++ b/sensitive-test/src/test/java/com/github/houbb/sensitive/test/model/sensitive/entry/CustomUserEntryObject.java
@@ -1,0 +1,58 @@
+package com.github.houbb.sensitive.test.model.sensitive.entry;
+
+import com.github.houbb.sensitive.test.annotation.custom.SensitiveEntryCustom;
+import com.github.houbb.sensitive.test.model.sensitive.User;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 对象中有列表，列表中放置的为对象
+ * @author dev-sxl
+ * date 2020-09-14
+ * @since 0.0.11
+ */
+public class CustomUserEntryObject {
+
+    @SensitiveEntryCustom
+    private User user;
+
+    @SensitiveEntryCustom
+    private List<User> userList;
+
+    @SensitiveEntryCustom
+    private User[] userArray;
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public List<User> getUserList() {
+        return userList;
+    }
+
+    public void setUserList(List<User> userList) {
+        this.userList = userList;
+    }
+
+    public User[] getUserArray() {
+        return userArray;
+    }
+
+    public void setUserArray(User[] userArray) {
+        this.userArray = userArray;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomUserEntryObject{" +
+                "user=" + user +
+                ", userList=" + userList +
+                ", userArray=" + Arrays.toString(userArray) +
+                '}';
+    }
+}

--- a/sensitive-test/src/test/java/com/github/houbb/sensitive/test/model/sensitive/entry/CustomUserGroup.java
+++ b/sensitive-test/src/test/java/com/github/houbb/sensitive/test/model/sensitive/entry/CustomUserGroup.java
@@ -1,0 +1,119 @@
+package com.github.houbb.sensitive.test.model.sensitive.entry;
+
+import com.github.houbb.sensitive.annotation.Sensitive;
+import com.github.houbb.sensitive.core.api.strategory.StrategyPassword;
+import com.github.houbb.sensitive.test.annotation.custom.SensitiveEntryCustom;
+import com.github.houbb.sensitive.test.model.sensitive.User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author dev-sxl
+ * date 2020-09-14
+ * @since 0.0.11
+ */
+public class CustomUserGroup {
+
+    /**
+     * 不参与脱敏的用户
+     */
+    private User coolUser;
+
+    @SensitiveEntryCustom
+    private User user;
+
+    @SensitiveEntryCustom
+    private List<User> userList;
+
+    @SensitiveEntryCustom
+    private Set<User> userSet;
+
+    @SensitiveEntryCustom
+    private Collection<User> userCollection;
+
+    /**
+     * SensitiveEntry 注解不会生效
+     * Sensitive 注解正常执行
+     */
+    @Sensitive(strategy = StrategyPassword.class)
+    @SensitiveEntryCustom
+    private String password;
+
+    /**
+     * SensitiveEntry 注解不会生效
+     */
+    @SensitiveEntryCustom
+    private Map<String, User> userMap;
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public User getCoolUser() {
+        return coolUser;
+    }
+
+    public void setCoolUser(User coolUser) {
+        this.coolUser = coolUser;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public List<User> getUserList() {
+        return userList;
+    }
+
+    public void setUserList(List<User> userList) {
+        this.userList = userList;
+    }
+
+    public Set<User> getUserSet() {
+        return userSet;
+    }
+
+    public void setUserSet(Set<User> userSet) {
+        this.userSet = userSet;
+    }
+
+    public Collection<User> getUserCollection() {
+        return userCollection;
+    }
+
+    public void setUserCollection(Collection<User> userCollection) {
+        this.userCollection = userCollection;
+    }
+
+    public Map<String, User> getUserMap() {
+        return userMap;
+    }
+
+    public void setUserMap(Map<String, User> userMap) {
+        this.userMap = userMap;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomUserGroup{" +
+                "coolUser=" + coolUser +
+                ", user=" + user +
+                ", userList=" + userList +
+                ", userSet=" + userSet +
+                ", userCollection=" + userCollection +
+                ", password='" + password + '\'' +
+                ", userMap=" + userMap +
+                '}';
+    }
+}


### PR DESCRIPTION
添加支持自定义级联脱敏注解,方便使用者进行二次封装;
当前支持 1.自定义脱敏策略, 2.自定义脱敏策略生效条件,
但却缺少自定义级联脱敏注解@SensitiveEntry注解的支持, 使用者若想对框架进行二次包装,就形成不了闭环(刚好我目前就有这个需求), 
故添加支持自定义级联脱敏注解的支持.